### PR TITLE
Feat/azure pipelines

### DIFF
--- a/DnDGen.Stress.Tests/DnDGen.Stress.Tests.csproj
+++ b/DnDGen.Stress.Tests/DnDGen.Stress.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DnDGen.Stress.Tests/GenerateOrFailTests.cs
+++ b/DnDGen.Stress.Tests/GenerateOrFailTests.cs
@@ -22,6 +22,9 @@ namespace DnDGen.Stress.Tests
         {
             options = new StressorOptions();
             options.RunningAssembly = Assembly.GetExecutingAssembly();
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 10;
+            options.OutputTimeLimitInSeconds = 1;
 
             output = new List<string>();
             mockLogger = new Mock<ILogger>();
@@ -42,8 +45,10 @@ namespace DnDGen.Stress.Tests
             Assert.That(() => stressor.GenerateOrFail(() => SlowGenerate(ref count), c => false), Throws.InstanceOf<AssertionException>().With.Message.EqualTo("Generation timed out"));
             stopwatch.Stop();
 
+            Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TestDuration).Within(.1).Seconds);
             Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(count, Is.LessThan(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations));
         }
 
         private int SlowGenerate(ref int count)
@@ -62,27 +67,35 @@ namespace DnDGen.Stress.Tests
             Assert.That(() => stressor.GenerateOrFail(() => count++, c => false), Throws.InstanceOf<AssertionException>().With.Message.EqualTo("Generation timed out"));
             stopwatch.Stop();
 
+            Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TestDuration).Within(.1).Seconds);
             Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit));
-            Assert.That(count, Is.EqualTo(Stressor.ConfidentIterations));
+            Assert.That(count, Is.EqualTo(options.ConfidenceIterations));
+            Assert.That(stressor.TestIterations, Is.EqualTo(options.ConfidenceIterations));
         }
 
         [Test]
         public void StopsWhenGenerated()
         {
+            options.ConfidenceIterations = 10_000;
+
             var count = 0;
 
             stopwatch.Start();
             var result = stressor.GenerateOrFail(() => count++, c => c > 9266);
             stopwatch.Stop();
 
+            Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TestDuration).Within(.1).Seconds);
             Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit));
             Assert.That(result, Is.EqualTo(9267));
             Assert.That(count, Is.EqualTo(9268));
+            Assert.That(stressor.TestIterations, Is.EqualTo(9268));
         }
 
         [Test]
         public void WritesStressDurationToConsole()
         {
+            options.ConfidenceIterations = 10_000;
+
             var count = 0;
 
             var result = stressor.GenerateOrFail(() => count++, c => c > 9266);
@@ -96,6 +109,8 @@ namespace DnDGen.Stress.Tests
         [Test]
         public void WritesStressSummaryToConsole()
         {
+            options.ConfidenceIterations = 10_000;
+
             var count = 0;
 
             var result = stressor.GenerateOrFail(() => count++, c => c == 9266);
@@ -105,9 +120,9 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:00."));
-            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 9267 (0.93%)"));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 9267 (92.67%)"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
@@ -120,9 +135,9 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:00."));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: FAILED"));
         }
 
@@ -138,18 +153,23 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:00.0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
         [Test]
         public void GenerateAndSucceed()
         {
-            var count = 0;
-            var result = stressor.GenerateOrFail(() => count++, c => c == 9266);
-            Assert.That(result, Is.EqualTo(9266));
+            options.ConfidenceIterations = 10_000;
+
+            var count = 1;
+            var result = stressor.GenerateOrFail(() => count += count, c => c >= 9266);
+
+            Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.EqualTo(14));
+            Assert.That(result, Is.EqualTo(16384));
         }
 
         [Test]
@@ -162,6 +182,8 @@ namespace DnDGen.Stress.Tests
         [Test]
         public void GenerateWithinGenerateOrFailHonorsTimeLimit()
         {
+            options.ConfidenceIterations = 10_000_000;
+
             var count = 0;
 
             stopwatch.Start();
@@ -174,8 +196,10 @@ namespace DnDGen.Stress.Tests
                 Throws.InstanceOf<AssertionException>());
             stopwatch.Stop();
 
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
             Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(count, Is.AtLeast(9266));
+            Assert.That(stressor.TestIterations, Is.AtLeast(8000));
+            Assert.That(count, Is.AtLeast(8000));
         }
 
         [Test]

--- a/DnDGen.Stress.Tests/GenerateOrFailTests.cs
+++ b/DnDGen.Stress.Tests/GenerateOrFailTests.cs
@@ -198,8 +198,8 @@ namespace DnDGen.Stress.Tests
 
             Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
             Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(stressor.TestIterations, Is.AtLeast(8000));
-            Assert.That(count, Is.AtLeast(8000));
+            Assert.That(stressor.TestIterations, Is.AtLeast(1000));
+            Assert.That(count, Is.AtLeast(9266 * (stressor.TestIterations - 1)));
         }
 
         [Test]

--- a/DnDGen.Stress.Tests/GenerateTests.cs
+++ b/DnDGen.Stress.Tests/GenerateTests.cs
@@ -21,6 +21,9 @@ namespace DnDGen.Stress.Tests
         {
             options = new StressorOptions();
             options.RunningAssembly = Assembly.GetExecutingAssembly();
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 10;
+            options.OutputTimeLimitInSeconds = 1;
 
             output = new List<string>();
             mockLogger = new Mock<ILogger>();
@@ -52,12 +55,12 @@ namespace DnDGen.Stress.Tests
             var count = 0;
 
             stopwatch.Start();
-            var result = stressor.Generate(() => count++, c => c == Stressor.ConfidentIterations + 1);
+            var result = stressor.Generate(() => count++, c => c == options.ConfidenceIterations + 1);
             stopwatch.Stop();
 
             Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit));
-            Assert.That(result, Is.EqualTo(Stressor.ConfidentIterations + 1));
-            Assert.That(count, Is.EqualTo(Stressor.ConfidentIterations + 2));
+            Assert.That(result, Is.EqualTo(options.ConfidenceIterations + 1));
+            Assert.That(count, Is.EqualTo(options.ConfidenceIterations + 2));
         }
 
         [Test]

--- a/DnDGen.Stress.Tests/StressAsyncTests.cs
+++ b/DnDGen.Stress.Tests/StressAsyncTests.cs
@@ -270,7 +270,8 @@ namespace DnDGen.Stress.Tests
                 await stressor.StressAsync(async () =>
                     await FailStressAsync(counts)));
 
-            Assert.That(counts, Has.Count.EqualTo(16));
+            var expectedCount = (10 / Environment.ProcessorCount + 1) * Environment.ProcessorCount;
+            Assert.That(counts, Has.Count.EqualTo(expectedCount));
             Assert.That(exception.StackTrace.Trim(), Does.Not.StartsWith("at DnDGen.Stress.Stressor.RunActionAsync"));
         }
 

--- a/DnDGen.Stress.Tests/StressAsyncTests.cs
+++ b/DnDGen.Stress.Tests/StressAsyncTests.cs
@@ -23,6 +23,9 @@ namespace DnDGen.Stress.Tests
         {
             options = new StressorOptions();
             options.RunningAssembly = Assembly.GetExecutingAssembly();
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 10;
+            options.OutputTimeLimitInSeconds = 1;
 
             output = new List<string>();
             mockLogger = new Mock<ILogger>();
@@ -44,7 +47,9 @@ namespace DnDGen.Stress.Tests
             stopwatch.Stop();
 
             Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(counts, Has.Count.LessThan(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(counts, Has.Count.LessThan(options.ConfidenceIterations));
         }
 
         private async Task SlowTestAsync(BlockingCollection<bool> collection)
@@ -67,15 +72,16 @@ namespace DnDGen.Stress.Tests
             options.RunningAssembly = null;
 
             stressor = new Stressor(options, mockLogger.Object);
-
             var counts = new BlockingCollection<bool>();
 
             stopwatch.Start();
             await stressor.StressAsync(async () => await FastTestAsync(counts));
             stopwatch.Stop();
 
-            Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit));
-            Assert.That(counts, Has.Count.EqualTo(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stopwatch.Elapsed).Within(.1).Seconds
+                .And.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.Positive.And.EqualTo(options.ConfidenceIterations));
+            Assert.That(counts, Has.Count.EqualTo(options.ConfidenceIterations));
         }
 
         [Test]
@@ -94,12 +100,16 @@ namespace DnDGen.Stress.Tests
             var counts = new BlockingCollection<bool>();
             await stressor.StressAsync(async () => await FastTestAsync(counts));
 
+            Assert.That(stressor.TestDuration, Is.GreaterThan(TimeSpan.FromSeconds(0))
+                .And.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.EqualTo(options.ConfidenceIterations));
+
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} (100.00%)"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
@@ -108,12 +118,15 @@ namespace DnDGen.Stress.Tests
         {
             Assert.That(async () => await stressor.StressAsync(FailedTestAsync), Throws.InstanceOf<AssertionException>());
 
+            Assert.That(stressor.TestDuration, Is.EqualTo(TimeSpan.FromSeconds(0)).Within(100).Milliseconds);
+            Assert.That(stressor.TestIterations, Is.Zero);
+
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:00.0"));
-            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 0 (0%)"));
-            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: 0"));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 0 (0.00%)"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: 0.00"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: FAILED"));
         }
 
@@ -128,35 +141,84 @@ namespace DnDGen.Stress.Tests
             var counts = new BlockingCollection<bool>();
             await stressor.StressAsync(async () => await SlowTestAsync(counts));
 
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:01.0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
         [Test]
-        public async Task StressATest()
+        public async Task StressATest_HitIterations()
         {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 1_000;
+            options.OutputTimeLimitInSeconds = 1_000;
+
             var counts = new BlockingCollection<bool>();
             await stressor.StressAsync(async () => await FastTestAsync(counts));
 
-            Assert.That(counts, Has.Count.AtLeast(100_000));
+            Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.AtLeast(options.ConfidenceIterations));
+            Assert.That(counts, Has.Count.AtLeast(options.ConfidenceIterations));
+        }
+
+        [Test]
+        public async Task StressATest_HitTimeLimit_Output()
+        {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 1_000_000;
+            options.BuildTimeLimitInSeconds = 1_000;
+            options.OutputTimeLimitInSeconds = 1;
+
+            stressor = new Stressor(options, mockLogger.Object);
+
+            var counts = new BlockingCollection<bool>();
+            await stressor.StressAsync(async () => await FastTestAsync(counts));
+
+            Assert.That(stressor.TimeLimit, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(counts, Has.Count.LessThan(options.ConfidenceIterations));
+        }
+
+        [Test]
+        public async Task StressATest_HitTimeLimit_Build()
+        {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 10_000_000;
+            options.BuildTimeLimitInSeconds = 3 * (StressorTests.TestCaseCount + StressorTests.TestCount);
+            options.OutputTimeLimitInSeconds = 10;
+
+            stressor = new Stressor(options, mockLogger.Object);
+
+            var counts = new BlockingCollection<bool>();
+            await stressor.StressAsync(async () => await FastTestAsync(counts));
+
+            Assert.That(stressor.TimeLimit, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(counts, Has.Count.LessThan(options.ConfidenceIterations));
         }
 
         [Test]
         public async Task GenerateWithinStressHonorsTimeLimit()
         {
+            options.ConfidenceIterations = 1_000_000;
+
             var counts = new BlockingCollection<bool>();
 
-            stopwatch.Start();
             await stressor.StressAsync(async () => await TestWithGenerateAsync(counts));
-            stopwatch.Stop();
 
-            Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit).Or.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(counts, Has.Count.LessThan(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
+            Assert.That(counts, Has.Count.LessThan(options.ConfidenceIterations));
         }
 
         private async Task TestWithGenerateAsync(BlockingCollection<bool> collection)
@@ -169,8 +231,13 @@ namespace DnDGen.Stress.Tests
             Assert.That(collection, Has.Count.Positive);
         }
 
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(10)]
         [TestCase(65)]
         [TestCase(70)]
+        [TestCase(100)]
+        [TestCase(1000)]
         public async Task PercentageIsAccurate(int testCount)
         {
             options.IsFullStress = true;
@@ -182,15 +249,15 @@ namespace DnDGen.Stress.Tests
             var counts = new BlockingCollection<bool>();
             await stressor.StressAsync(async () => await SlowTestAsync(counts));
 
-            var time = stressor.TimeLimit.ToString().Substring(0, 10);
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
 
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: {time}"));
-            Assert.That(output[2], Does.Contain($"(100"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
@@ -241,12 +308,13 @@ namespace DnDGen.Stress.Tests
 
             await stressor.StressAsync(async () => await FastTestAsync(counts));
 
-            var expectedCount = Stressor.ConfidentIterations;
-            if (Stressor.ConfidentIterations % parallel != 0)
+            var expectedCount = options.ConfidenceIterations;
+            if (options.ConfidenceIterations % parallel != 0)
             {
-                expectedCount += parallel - Stressor.ConfidentIterations % parallel;
+                expectedCount += parallel - options.ConfidenceIterations % parallel;
             }
 
+            Assert.That(stressor.TestIterations, Is.EqualTo(expectedCount));
             Assert.That(counts, Has.Count.EqualTo(expectedCount));
         }
     }

--- a/DnDGen.Stress.Tests/StressTests.cs
+++ b/DnDGen.Stress.Tests/StressTests.cs
@@ -22,6 +22,9 @@ namespace DnDGen.Stress.Tests
         {
             options = new StressorOptions();
             options.RunningAssembly = Assembly.GetExecutingAssembly();
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 10;
+            options.OutputTimeLimitInSeconds = 1;
 
             output = new List<string>();
             mockLogger = new Mock<ILogger>();
@@ -43,7 +46,9 @@ namespace DnDGen.Stress.Tests
             stopwatch.Stop();
 
             Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(count, Is.LessThan(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations));
         }
 
         private void SlowTest(ref int count)
@@ -73,8 +78,10 @@ namespace DnDGen.Stress.Tests
             stressor.Stress(() => FastTest(ref count));
             stopwatch.Stop();
 
-            Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit));
-            Assert.That(count, Is.EqualTo(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stopwatch.Elapsed).Within(.1).Seconds
+                .And.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.Positive.And.EqualTo(options.ConfidenceIterations));
+            Assert.That(count, Is.EqualTo(options.ConfidenceIterations));
         }
 
         [Test]
@@ -96,9 +103,9 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
@@ -110,9 +117,9 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:00.0"));
-            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 0 (0%)"));
-            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: 0"));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 0 (0.00%)"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: 0.00"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: FAILED"));
         }
 
@@ -130,31 +137,77 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:01.0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
         [Test]
-        public void StressATest()
+        public void StressATest_HitIterations()
         {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 1_000;
+            options.OutputTimeLimitInSeconds = 1_000;
+
             var count = 0;
             stressor.Stress(() => FastTest(ref count));
-            Assert.That(count, Is.AtLeast(100_000));
+
+            Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.AtLeast(options.ConfidenceIterations));
+            Assert.That(count, Is.AtLeast(options.ConfidenceIterations));
+        }
+
+        [Test]
+        public void StressATest_HitTimeLimit_Output()
+        {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 10_000_000;
+            options.BuildTimeLimitInSeconds = 1_000;
+            options.OutputTimeLimitInSeconds = 1;
+
+            stressor = new Stressor(options, mockLogger.Object);
+
+            var count = 0;
+            stressor.Stress(() => FastTest(ref count));
+
+            Assert.That(stressor.TimeLimit, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations));
+        }
+
+        [Test]
+        public void StressATest_HitTimeLimit_Build()
+        {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 10_000_000;
+            options.BuildTimeLimitInSeconds = 3 * (StressorTests.TestCaseCount + StressorTests.TestCount);
+            options.OutputTimeLimitInSeconds = 10;
+
+            stressor = new Stressor(options, mockLogger.Object);
+
+            var count = 0;
+            stressor.Stress(() => FastTest(ref count));
+
+            Assert.That(stressor.TimeLimit, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations));
         }
 
         [Test]
         public void GenerateWithinStressHonorsTimeLimit()
         {
+            options.ConfidenceIterations = 10_000_000;
+
             var count = 0;
-
-            stopwatch.Start();
             stressor.Stress(() => TestWithGenerate(ref count));
-            stopwatch.Stop();
 
-            Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit).Or.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(count, Is.LessThan(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations));
         }
 
         private void TestWithGenerate(ref int count)
@@ -164,8 +217,13 @@ namespace DnDGen.Stress.Tests
             Assert.That(count, Is.AtLeast(2));
         }
 
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(10)]
         [TestCase(65)]
         [TestCase(70)]
+        [TestCase(100)]
+        [TestCase(1000)]
         public void PercentageIsAccurate(int testCount)
         {
             options.IsFullStress = true;
@@ -177,15 +235,15 @@ namespace DnDGen.Stress.Tests
             var count = 0;
             stressor.Stress(() => SlowTest(ref count));
 
-            var time = stressor.TimeLimit.ToString().Substring(0, 10);
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
 
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: {time}"));
-            Assert.That(output[2], Does.Contain($"(100"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 

--- a/DnDGen.Stress.Tests/StressWithSetupAndTeardownAsyncTests.cs
+++ b/DnDGen.Stress.Tests/StressWithSetupAndTeardownAsyncTests.cs
@@ -309,13 +309,23 @@ namespace DnDGen.Stress.Tests
             Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
             Assert.That(stressor.TestIterations, Is.EqualTo(9264));
 
-            var expectedCount = (9266 / Environment.ProcessorCount + 1) * Environment.ProcessorCount;
+            var expectedCount = GetExpectedAsyncCount(9266);
             Assert.That(counts, Has.Count.EqualTo(expectedCount), "Count");
             Assert.That(setups, Has.Count.EqualTo(expectedCount), "Setup");
             Assert.That(teardowns, Has.Count.EqualTo(expectedCount), "Tear Down");
-            Assert.That(counts, Has.Count.EqualTo(9272), "Count");
-            Assert.That(setups, Has.Count.EqualTo(9272), "Setup");
-            Assert.That(teardowns, Has.Count.EqualTo(9272), "Tear Down");
+        }
+
+        private int GetExpectedAsyncCount(int cutoff) => GetExpectedAsyncCount(cutoff, Environment.ProcessorCount);
+
+        private int GetExpectedAsyncCount(int cutoff, int parallel)
+        {
+            var expectedCount = cutoff;
+            if (cutoff % parallel != 0)
+            {
+                expectedCount += parallel - cutoff % parallel;
+            }
+
+            return expectedCount;
         }
 
         [Test]
@@ -401,7 +411,7 @@ namespace DnDGen.Stress.Tests
                     async () => await FailStressAsync(counts),
                     () => TestTeardown(teardowns)));
 
-            var expectedCount = (10 / Environment.ProcessorCount + 1) * Environment.ProcessorCount;
+            var expectedCount = GetExpectedAsyncCount(10);
             Assert.That(counts, Has.Count.EqualTo(expectedCount));
             Assert.That(setups, Has.Count.EqualTo(expectedCount));
             Assert.That(teardowns, Has.Count.EqualTo(expectedCount));
@@ -447,12 +457,7 @@ namespace DnDGen.Stress.Tests
                 async () => await FastTestAsync(counts),
                 () => TestTeardown(teardowns));
 
-            var expectedCount = options.ConfidenceIterations;
-            if (options.ConfidenceIterations % parallel != 0)
-            {
-                expectedCount += parallel - options.ConfidenceIterations % parallel;
-            }
-
+            var expectedCount = GetExpectedAsyncCount(options.ConfidenceIterations, parallel);
             Assert.That(counts, Has.Count.EqualTo(expectedCount));
             Assert.That(setups, Has.Count.EqualTo(expectedCount));
             Assert.That(teardowns, Has.Count.EqualTo(expectedCount));

--- a/DnDGen.Stress.Tests/StressWithSetupAndTeardownAsyncTests.cs
+++ b/DnDGen.Stress.Tests/StressWithSetupAndTeardownAsyncTests.cs
@@ -155,8 +155,8 @@ namespace DnDGen.Stress.Tests
                     FailedTestAsync,
                     () => teardowns.Add(true)),
                 Throws.InstanceOf<AssertionException>());
-            Assert.That(setups, Has.Count.EqualTo(8));
-            Assert.That(teardowns, Has.Count.EqualTo(8));
+            Assert.That(setups, Has.Count.EqualTo(Environment.ProcessorCount));
+            Assert.That(teardowns, Has.Count.EqualTo(Environment.ProcessorCount));
 
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
@@ -308,6 +308,11 @@ namespace DnDGen.Stress.Tests
 
             Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
             Assert.That(stressor.TestIterations, Is.EqualTo(9264));
+
+            var expectedCount = (9266 / Environment.ProcessorCount + 1) * Environment.ProcessorCount;
+            Assert.That(counts, Has.Count.EqualTo(expectedCount), "Count");
+            Assert.That(setups, Has.Count.EqualTo(expectedCount), "Setup");
+            Assert.That(teardowns, Has.Count.EqualTo(expectedCount), "Tear Down");
             Assert.That(counts, Has.Count.EqualTo(9272), "Count");
             Assert.That(setups, Has.Count.EqualTo(9272), "Setup");
             Assert.That(teardowns, Has.Count.EqualTo(9272), "Tear Down");
@@ -396,9 +401,10 @@ namespace DnDGen.Stress.Tests
                     async () => await FailStressAsync(counts),
                     () => TestTeardown(teardowns)));
 
-            Assert.That(counts, Has.Count.EqualTo(16));
-            Assert.That(setups, Has.Count.EqualTo(16));
-            Assert.That(teardowns, Has.Count.EqualTo(16));
+            var expectedCount = (10 / Environment.ProcessorCount + 1) * Environment.ProcessorCount;
+            Assert.That(counts, Has.Count.EqualTo(expectedCount));
+            Assert.That(setups, Has.Count.EqualTo(expectedCount));
+            Assert.That(teardowns, Has.Count.EqualTo(expectedCount));
             Assert.That(exception.StackTrace.Trim(), Does.Not.StartsWith("at DnDGen.Stress.Stressor.RunActionAsync"));
         }
 

--- a/DnDGen.Stress.Tests/StressWithSetupAndTeardownTests.cs
+++ b/DnDGen.Stress.Tests/StressWithSetupAndTeardownTests.cs
@@ -22,6 +22,9 @@ namespace DnDGen.Stress.Tests
         {
             options = new StressorOptions();
             options.RunningAssembly = Assembly.GetExecutingAssembly();
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 10;
+            options.OutputTimeLimitInSeconds = 1;
 
             output = new List<string>();
             mockLogger = new Mock<ILogger>();
@@ -50,11 +53,14 @@ namespace DnDGen.Stress.Tests
             stopwatch.Stop();
 
             Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(count, Is.LessThan(Stressor.ConfidentIterations));
-            Assert.That(setup, Is.LessThan(Stressor.ConfidentIterations));
-            Assert.That(teardown, Is.LessThan(Stressor.ConfidentIterations));
-            Assert.That(count, Is.EqualTo(setup));
-            Assert.That(count, Is.EqualTo(teardown));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(setup, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(teardown, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.EqualTo(setup)
+                .And.EqualTo(teardown)
+                .And.EqualTo(options.ConfidenceIterations));
         }
 
         private void SlowTest(ref int count)
@@ -91,10 +97,12 @@ namespace DnDGen.Stress.Tests
 
             stopwatch.Stop();
 
-            Assert.That(stopwatch.Elapsed, Is.LessThan(stressor.TimeLimit));
-            Assert.That(count, Is.EqualTo(Stressor.ConfidentIterations));
-            Assert.That(setup, Is.EqualTo(Stressor.ConfidentIterations));
-            Assert.That(teardown, Is.EqualTo(Stressor.ConfidentIterations));
+            Assert.That(stressor.TestDuration, Is.EqualTo(stopwatch.Elapsed).Within(.1).Seconds
+                .And.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.Positive.And.EqualTo(options.ConfidenceIterations));
+            Assert.That(count, Is.EqualTo(options.ConfidenceIterations));
+            Assert.That(setup, Is.EqualTo(options.ConfidenceIterations));
+            Assert.That(teardown, Is.EqualTo(options.ConfidenceIterations));
         }
 
         [Test]
@@ -128,9 +136,9 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
@@ -147,9 +155,9 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:00.0"));
-            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 0 (0%)"));
-            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: 0"));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: 0 (0.00%)"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: 0.00"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: FAILED"));
         }
 
@@ -173,23 +181,85 @@ namespace DnDGen.Stress.Tests
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: 00:00:01.0"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 
         [Test]
-        public void StressATestWithSetupAndTeardown()
+        public void StressATestWithSetupAndTeardown_HitIterations()
         {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 1_000;
+            options.BuildTimeLimitInSeconds = 1_000;
+            options.OutputTimeLimitInSeconds = 1_000;
+
             var count = 0;
             var setup = 0;
             var teardown = 0;
-
             stressor.Stress(() => TestSetup(ref setup), () => FastTest(ref count), () => TestTeardown(ref teardown));
-            Assert.That(count, Is.AtLeast(10000), "Count");
-            Assert.That(setup, Is.AtLeast(10000), "Setup");
-            Assert.That(teardown, Is.AtLeast(10000), "Tear Down");
+
+            Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.AtLeast(options.ConfidenceIterations));
+            Assert.That(count, Is.AtLeast(options.ConfidenceIterations), "Count");
+            Assert.That(setup, Is.AtLeast(options.ConfidenceIterations), "Setup");
+            Assert.That(teardown, Is.AtLeast(options.ConfidenceIterations), "Tear Down");
+            Assert.That(count, Is.EqualTo(stressor.TestIterations)
+                .And.EqualTo(setup)
+                .And.EqualTo(teardown));
+        }
+
+        [Test]
+        public void StressATestWithSetupAndTeardown_HitTimeLimit_Output()
+        {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 10_000_000;
+            options.BuildTimeLimitInSeconds = 1_000;
+            options.OutputTimeLimitInSeconds = 1;
+
+            stressor = new Stressor(options, mockLogger.Object);
+
+            var count = 0;
+            var setup = 0;
+            var teardown = 0;
+            stressor.Stress(() => TestSetup(ref setup), () => FastTest(ref count), () => TestTeardown(ref teardown));
+
+            Assert.That(stressor.TimeLimit, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations), "Count");
+            Assert.That(setup, Is.LessThan(options.ConfidenceIterations), "Setup");
+            Assert.That(teardown, Is.LessThan(options.ConfidenceIterations), "Tear Down");
+            Assert.That(count, Is.EqualTo(stressor.TestIterations)
+                .And.EqualTo(setup)
+                .And.EqualTo(teardown));
+        }
+
+        [Test]
+        public void StressATestWithSetupAndTeardown_HitTimeLimit_Build()
+        {
+            options.IsFullStress = true;
+            options.ConfidenceIterations = 10_000_000;
+            options.BuildTimeLimitInSeconds = 3 * (StressorTests.TestCaseCount + StressorTests.TestCount);
+            options.OutputTimeLimitInSeconds = 10;
+
+            stressor = new Stressor(options, mockLogger.Object);
+
+            var count = 0;
+            var setup = 0;
+            var teardown = 0;
+            stressor.Stress(() => TestSetup(ref setup), () => FastTest(ref count), () => TestTeardown(ref teardown));
+
+            Assert.That(stressor.TimeLimit, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations), "Count");
+            Assert.That(setup, Is.LessThan(options.ConfidenceIterations), "Setup");
+            Assert.That(teardown, Is.LessThan(options.ConfidenceIterations), "Tear Down");
+            Assert.That(count, Is.EqualTo(stressor.TestIterations)
+                .And.EqualTo(setup)
+                .And.EqualTo(teardown));
         }
 
         private void TestSetup(ref int setup)
@@ -205,11 +275,15 @@ namespace DnDGen.Stress.Tests
         [Test]
         public void StressAFailedTestWithSetupAndTeardown()
         {
+            options.ConfidenceIterations = 10_000;
+
             var count = 0;
             var setup = 0;
             var teardown = 0;
 
             Assert.That(() => stressor.Stress(() => TestSetup(ref setup), () => FastTest(ref count, 9266), () => TestTeardown(ref teardown)), Throws.InstanceOf<AssertionException>());
+            Assert.That(stressor.TestDuration, Is.LessThan(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.EqualTo(9265));
             Assert.That(count, Is.EqualTo(9266), "Count");
             Assert.That(setup, Is.EqualTo(9266), "Setup");
             Assert.That(teardown, Is.EqualTo(9266), "Tear Down");
@@ -218,26 +292,24 @@ namespace DnDGen.Stress.Tests
         [Test]
         public void GenerateWithinStressWithSetupAndTeardownHonorsTimeLimit()
         {
+            options.ConfidenceIterations = 10_000_000;
+
             var count = 0;
             var setup = 0;
             var teardown = 0;
-
-            stopwatch.Start();
 
             stressor.Stress(
                 () => TestSetup(ref setup),
                 () => TestWithGenerate(ref count),
                 () => TestTeardown(ref teardown));
 
-            stopwatch.Stop();
-
-            Assert.That(stopwatch.Elapsed, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
-            Assert.That(count, Is.LessThan(Stressor.ConfidentIterations), "Count");
-            Assert.That(setup, Is.LessThan(Stressor.ConfidentIterations), "Setup");
-            Assert.That(teardown, Is.LessThan(Stressor.ConfidentIterations), "Tear Down");
-            Assert.That(count, Is.AtLeast(1000), "Count");
-            Assert.That(setup, Is.AtLeast(1000), "Setup");
-            Assert.That(teardown, Is.AtLeast(1000), "Tear Down");
+            Assert.That(stressor.TestDuration, Is.EqualTo(stressor.TimeLimit).Within(.1).Seconds);
+            Assert.That(count, Is.LessThan(options.ConfidenceIterations)
+                .And.AtLeast(1000), "Count");
+            Assert.That(setup, Is.LessThan(options.ConfidenceIterations)
+                .And.AtLeast(1000), "Setup");
+            Assert.That(teardown, Is.LessThan(options.ConfidenceIterations)
+                .And.AtLeast(1000), "Tear Down");
         }
 
         private void TestWithGenerate(ref int count)
@@ -250,8 +322,13 @@ namespace DnDGen.Stress.Tests
             Assert.That(count, Is.Positive);
         }
 
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(10)]
         [TestCase(65)]
         [TestCase(70)]
+        [TestCase(100)]
+        [TestCase(1000)]
         public void PercentageIsAccurate(int testCount)
         {
             options.IsFullStress = true;
@@ -269,15 +346,15 @@ namespace DnDGen.Stress.Tests
                 () => SlowTest(ref count),
                 () => TestTeardown(ref teardown));
 
-            var time = stressor.TimeLimit.ToString().Substring(0, 10);
+            Assert.That(stressor.TestDuration, Is.AtLeast(stressor.TimeLimit));
+            Assert.That(stressor.TestIterations, Is.LessThan(options.ConfidenceIterations));
 
             Assert.That(output, Is.Not.Empty.And.Count.EqualTo(6));
             Assert.That(output[0], Is.EqualTo($"Stress timeout is {stressor.TimeLimit}"));
             Assert.That(output[1], Is.EqualTo($"Stress test complete"));
-            Assert.That(output[2], Does.StartWith($"\tTime: {time}"));
-            Assert.That(output[2], Does.Contain($"(100"));
-            Assert.That(output[3], Does.StartWith($"\tCompleted Iterations: "));
-            Assert.That(output[4], Does.StartWith($"\tIterations Per Second: "));
+            Assert.That(output[2], Is.EqualTo($"\tTime: {stressor.TestDuration} ({stressor.TestDuration.TotalSeconds / stressor.TimeLimit.TotalSeconds:P})"));
+            Assert.That(output[3], Is.EqualTo($"\tCompleted Iterations: {stressor.TestIterations} ({(double)stressor.TestIterations / options.ConfidenceIterations:P})"));
+            Assert.That(output[4], Is.EqualTo($"\tIterations Per Second: {stressor.TestIterations / stressor.TestDuration.TotalSeconds:N2}"));
             Assert.That(output[5], Is.EqualTo($"\tLikely Status: PASSED"));
         }
 

--- a/DnDGen.Stress.Tests/StressWithSetupAndTeardownTests.cs
+++ b/DnDGen.Stress.Tests/StressWithSetupAndTeardownTests.cs
@@ -59,8 +59,7 @@ namespace DnDGen.Stress.Tests
             Assert.That(setup, Is.LessThan(options.ConfidenceIterations));
             Assert.That(teardown, Is.LessThan(options.ConfidenceIterations));
             Assert.That(count, Is.EqualTo(setup)
-                .And.EqualTo(teardown)
-                .And.EqualTo(options.ConfidenceIterations));
+                .And.EqualTo(teardown));
         }
 
         private void SlowTest(ref int count)

--- a/DnDGen.Stress.Tests/StressorOptionsTests.cs
+++ b/DnDGen.Stress.Tests/StressorOptionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.Reflection;
 
 namespace DnDGen.Stress.Tests
@@ -16,6 +17,14 @@ namespace DnDGen.Stress.Tests
             options.RunningAssembly = Assembly.GetExecutingAssembly();
         }
 
+        [TestCase(StressorOptions.DefaultBuildTimeLimitInSeconds, 60 * 60)]
+        [TestCase(StressorOptions.DefaultOutputTimeLimitInSeconds, 10 * 60)]
+        [TestCase(StressorOptions.DefaultConfidenceIterations, 1_000_000)]
+        public void DefaultConstants(int constant, int value)
+        {
+            Assert.That(constant, Is.EqualTo(value));
+        }
+
         [Test]
         public void StressorOptionsAreInitialized()
         {
@@ -23,8 +32,12 @@ namespace DnDGen.Stress.Tests
 
             Assert.That(options.IsFullStress, Is.False);
             Assert.That(options.RunningAssembly, Is.Null);
-            Assert.That(options.TestCount, Is.EqualTo(0));
+            Assert.That(options.TestCount, Is.Zero);
             Assert.That(options.TimeLimitPercentage, Is.EqualTo(1));
+            Assert.That(options.OutputTimeLimitInSeconds, Is.EqualTo(StressorOptions.DefaultOutputTimeLimitInSeconds));
+            Assert.That(options.BuildTimeLimitInSeconds, Is.EqualTo(StressorOptions.DefaultBuildTimeLimitInSeconds));
+            Assert.That(options.ConfidenceIterations, Is.EqualTo(StressorOptions.DefaultConfidenceIterations));
+            Assert.That(options.MaxAsyncBatch, Is.EqualTo(Environment.ProcessorCount));
         }
 
         [Test]

--- a/DnDGen.Stress/StressorOptions.cs
+++ b/DnDGen.Stress/StressorOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 
 namespace DnDGen.Stress
 {
@@ -9,6 +10,13 @@ namespace DnDGen.Stress
         public Assembly RunningAssembly { get; set; }
         public double TimeLimitPercentage { get; set; }
         public int MaxAsyncBatch { get; set; }
+        public int OutputTimeLimitInSeconds { get; set; }
+        public int BuildTimeLimitInSeconds { get; set; }
+        public int ConfidenceIterations { get; set; }
+
+        public const int DefaultOutputTimeLimitInSeconds = 10 * 60;
+        public const int DefaultBuildTimeLimitInSeconds = 60 * 60;
+        public const int DefaultConfidenceIterations = 1000000;
 
         public virtual bool AreValid
         {
@@ -24,7 +32,10 @@ namespace DnDGen.Stress
         public StressorOptions()
         {
             TimeLimitPercentage = 1;
-            MaxAsyncBatch = 8;
+            MaxAsyncBatch = Environment.ProcessorCount;
+            OutputTimeLimitInSeconds = DefaultOutputTimeLimitInSeconds;
+            BuildTimeLimitInSeconds = DefaultBuildTimeLimitInSeconds;
+            ConfidenceIterations = DefaultConfidenceIterations;
         }
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,10 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-- main
+- master
+- develop
+- feat/*
+- bug/*
 
 pool:
   vmImage: 'windows-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,31 @@
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- main
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: 'DnDGen.Stress.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    command: build
+    projects: './DnDGen.Stress/DnDGen.Stress.csproj'
+    arguments: '--configuration $(buildConfiguration)'
+- task: DotNetCoreCLI@2
+  displayName: Unit Tests
+  inputs:
+    command: test
+    projects: './DnDGen.Stress.Tests/DnDGen.Stress.Tests.csproj'
+    arguments: '-v normal'
+
+# Need to add nuget push from master


### PR DESCRIPTION
* Make confidence iterations, build timeout, and output timeout configurable
* Default build timeout to 1 hour
* Default output timeout to 10 minutes
* Better test assertions (more precise)
* Update nuget packages
* Test Iterations and Test Duration now accessible via the stressor
* Default max async is the number of processors (so specific to environment)